### PR TITLE
hotfix: change the order of city name and country in filter

### DIFF
--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -107,7 +107,7 @@ const DropDown: FC<DropDownProps> = ({
 									: {}
 							}
 						>
-							{capitalizeFirstLetter(item.city)}/{capitalizeFirstLetter(item.country)}
+							{capitalizeFirstLetter(item.country)}/{capitalizeFirstLetter(item.city)}
 						</li>
 					))}
 				</ul>


### PR DESCRIPTION
change the order of city name and country in filter